### PR TITLE
Fix collector hostname to show host machine name instead of container ID

### DIFF
--- a/collector/collector/config.py
+++ b/collector/collector/config.py
@@ -8,6 +8,37 @@ from dataclasses import dataclass
 from dotenv import load_dotenv
 
 
+def _get_collector_host() -> str:
+    """Determine the collector host name.
+
+    Priority:
+    1. COLLECTOR_HOST env var (if set)
+    2. Hostname file in mounted volume (for Docker containers)
+    3. socket.gethostname() fallback
+
+    Side effect: If COLLECTOR_HOST env var is set but hostname file doesn't exist,
+    write it to the file. This allows existing installs to auto-migrate when
+    Watchtower pulls the updated image (no reinstall needed).
+    """
+    hostname_file = Path("/home/collector/.claude-collector/hostname")
+
+    env_host = os.getenv("COLLECTOR_HOST")
+    if env_host:
+        # Persist to file for future runs (survives Watchtower updates)
+        if not hostname_file.exists():
+            try:
+                hostname_file.parent.mkdir(parents=True, exist_ok=True)
+                hostname_file.write_text(env_host + "\n")
+            except OSError:
+                pass  # Best effort - file write is optional
+        return env_host
+
+    if hostname_file.exists():
+        return hostname_file.read_text().strip()
+
+    return socket.gethostname()
+
+
 @dataclass
 class Config:
     """Collector configuration."""
@@ -32,7 +63,7 @@ class Config:
             db_name=os.getenv("DB_NAME", "claude_logs"),
             db_user=os.getenv("DB_USER", "claude_admin"),
             db_password=os.getenv("DB_PASSWORD", ""),
-            collector_host=os.getenv("COLLECTOR_HOST", socket.gethostname()),
+            collector_host=_get_collector_host(),
             claude_projects_path=Path(
                 os.getenv("CLAUDE_PROJECTS_PATH", Path.home() / ".claude" / "projects")
             ),

--- a/collector/install.sh
+++ b/collector/install.sh
@@ -47,6 +47,12 @@ if [ -z "$DB_PASSWORD" ]; then
     exit 1
 fi
 
+# Create collector directory and write hostname file
+# This persists the host machine's name so the container can read it
+# (socket.gethostname() inside container returns container ID)
+mkdir -p "$HOME/.claude-collector"
+hostname > "$HOME/.claude-collector/hostname"
+
 # Pull latest image
 echo "Pulling latest collector image..."
 docker pull "$IMAGE"


### PR DESCRIPTION
## Summary
- Adds `_get_collector_host()` function that reads hostname from a file in the mounted volume
- Updates `install.sh` to write the hostname file on new installs
- Auto-persists `COLLECTOR_HOST` env var to file for recent installs (no action needed)

## For existing users
Run this one-liner to fix:
```bash
hostname > ~/.claude-collector/hostname
```

Fixes #2

## Test plan
- [ ] Verify new installs create hostname file
- [ ] Verify collector reads hostname from file correctly
- [ ] Verify existing installs with COLLECTOR_HOST env var auto-migrate

🤖 Generated with [Claude Code](https://claude.com/claude-code)